### PR TITLE
Add support for programmatic navigation in NavigationStack

### DIFF
--- a/PokemonLibrary/Features/Home/HomeView.swift
+++ b/PokemonLibrary/Features/Home/HomeView.swift
@@ -20,15 +20,14 @@ struct HomeView: View {
                     Text("Loading...")
                 case .loaded(let pokemons):
                     List(pokemons, id: \.name) { pokemon in
-                        HStack {
-                            Text(pokemon.name.capitalized)
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.gray)
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            navigationPath.append(pokemon)
+                        NavigationLink(value: pokemon) {
+                            HStack {
+                                Text(pokemon.name.capitalized)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundColor(.gray)
+                            }
+                            .contentShape(Rectangle())
                         }
                     }
                 case .error(let networkError):


### PR DESCRIPTION
## 🔍 What does this PR do?
<!-- Briefly explain the purpose of this pull request -->
Add support for programmatic navigation through `NavigationLink` & `NavigationDestination` to fully utilize the `NavigationStack` and `NavigationPath`, the most recent navigation in SwiftUI. It allows us to move between views using code instead of relying on user interactions like tapping a button or list item. We define the navigation once, and reuse it across all views inside `NavigationStack`.

## ✅ Changes
<!-- List the changes made in this PR, and whats the impact -->
The current codebase doesn't support a programmatic navigation, as it uses `.onTapGesture` to manipulate the `NavigationPath` (i.e. insert or popping data). By using `NavigationLink` & `NavigationDestination`, `NavigationStack` handles the `NavigationPath` automatically.
- Changed the use of `.onTapGesture` to `NavigationLink` and `.navigationDestination` to manipulate the `NavigationPath`.

## 🚨 Checklist
- [x] I have tested my changes in Simulator
- [ ] I have tested my changes in Real device
